### PR TITLE
arm: DT: msm8998: Add arm-cpu-mon nodes for both clusters

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998.dtsi
@@ -842,6 +842,31 @@
 			< 1804000 13763 >;
 	};
 
+	devfreq_compute0: qcom,devfreq-compute0 {
+		compatible = "qcom,arm-cpu-mon";
+		qcom,cpulist = <&CPU0 &CPU1 &CPU2 &CPU3>;
+		qcom,target-dev = <&mincpubw>;
+		qcom,core-dev-table =
+                        <  300000 1525 >,
+                        <  499200 3143 >,
+                        < 1113600 4173 >,
+                        < 1881600 5859 >;
+	};
+
+	devfreq_compute2: qcom,devfreq-compute2 {
+		compatible = "qcom,arm-cpu-mon";
+		qcom,cpulist = <&CPU4 &CPU5 &CPU6 &CPU7>;
+		qcom,target-dev = <&mincpubw>;
+		qcom,core-dev-table =
+                        <  300000  1525 >,
+                        <  480000  3143 >,
+                        <  900000  4173 >,
+                        < 1017000  7759 >,
+                        < 1296000  9887 >,
+                        < 1555000 11863 >,
+                        < 1804000 13763 >;
+	};
+
 	devfreq_cpufreq: devfreq-cpufreq {
 		mincpubw-cpufreq {
 			target-dev = <&mincpubw>;


### PR DESCRIPTION
We manage the bandwidth through the arm-cpu-mon driver too,
so that in case of sudden spikes in CPU usage, we raise the
msm_bus bandwidth to avoid slowdowns.

*Based on https://github.com/AOSiP-Devices/kernel_zuk_msm8996/commit/1f4d098e3d7e0283030113a575342f4ec9b3fcb3

Signed-off-by: celtare21 <celtare21@gmail.com>